### PR TITLE
[Fix] Draft mode cookies were not being properly set

### DIFF
--- a/src/lib/draftMode.ts
+++ b/src/lib/draftMode.ts
@@ -18,9 +18,8 @@ function jwtToken() {
 export function enableDraftMode(context: APIContext) {
   context.cookies.set(DRAFT_MODE_COOKIE_NAME, jwtToken(), {
     path: '/',
-    sameSite: 'none',
+    sameSite: 'lax',
     httpOnly: false,
-    ...({ partitioned: true } as AstroCookieSetOptions),
   });
 }
 
@@ -30,9 +29,8 @@ export function enableDraftMode(context: APIContext) {
 export function disableDraftMode(context: APIContext) {
   context.cookies.delete(DRAFT_MODE_COOKIE_NAME, {
     path: '/',
-    sameSite: 'none',
+    sameSite: 'lax',
     httpOnly: false,
-    ...({ partitioned: true } as AstroCookieSetOptions),
   });
 }
 

--- a/src/pages/api/draft-mode/enable/index.ts
+++ b/src/pages/api/draft-mode/enable/index.ts
@@ -11,7 +11,7 @@ export const GET: APIRoute = (event) => {
 
   // Parse query string parameters
   const token = url.searchParams.get('token');
-  const redirectUrl = url.searchParams.get('url') || '/';
+  const redirectUrl = url.searchParams.get('url');
 
   try {
     // Ensure that the request is coming from a trusted source
@@ -20,13 +20,24 @@ export const GET: APIRoute = (event) => {
     }
 
     // Avoid open redirect vulnerabilities
-    if (redirectUrl.startsWith('http://') || redirectUrl.startsWith('https://')) {
-      return invalidRequestResponse('URL must be relative!', 422);
+    if (redirectUrl) {
+      if (
+        redirectUrl.startsWith('http://') ||
+        redirectUrl.startsWith('https://') ||
+        redirectUrl.startsWith('//')
+      ) {
+        return invalidRequestResponse('URL must be relative!', 422);
+      }
     }
 
     enableDraftMode(event);
   } catch (error) {
     return handleUnexpectedError(error);
+  }
+
+  // If no redirect URL, just set the cookie and return a 204 no content
+  if (!redirectUrl) {
+    return new Response(null, { status: 204 });
   }
 
   return event.redirect(redirectUrl, 307);

--- a/src/pages/api/draft-mode/enable/index.ts
+++ b/src/pages/api/draft-mode/enable/index.ts
@@ -3,6 +3,15 @@ import { SECRET_API_TOKEN } from 'astro:env/server';
 import { enableDraftMode } from '~/lib/draftMode';
 import { handleUnexpectedError, invalidRequestResponse } from '../../utils';
 
+const isExternalOrInvalidUrl = (url: string, hostname: string) => {
+  try {
+    const parsed = new URL(url, `http://${hostname}`);
+    return parsed.hostname !== hostname;
+  } catch {
+    return true;
+  }
+};
+
 /**
  * This route handler enables Draft Mode and redirects to the given URL.
  */
@@ -20,14 +29,8 @@ export const GET: APIRoute = (event) => {
     }
 
     // Avoid open redirect vulnerabilities
-    if (redirectUrl) {
-      if (
-        redirectUrl.startsWith('http://') ||
-        redirectUrl.startsWith('https://') ||
-        redirectUrl.startsWith('//')
-      ) {
-        return invalidRequestResponse('URL must be relative!', 422);
-      }
+    if (redirectUrl && isExternalOrInvalidUrl(redirectUrl, event.url.hostname)) {
+      return invalidRequestResponse('URL must be relative!', 422);
     }
 
     enableDraftMode(event);

--- a/src/pages/api/draft-mode/enable/index.ts
+++ b/src/pages/api/draft-mode/enable/index.ts
@@ -3,7 +3,7 @@ import { SECRET_API_TOKEN } from 'astro:env/server';
 import { enableDraftMode } from '~/lib/draftMode';
 import { handleUnexpectedError, invalidRequestResponse } from '../../utils';
 
-const isExternalOrInvalidUrl = (url: string, hostname: string) => {
+const isExternalOrInvalidUrl = (url: string, hostname: string):boolean => {
   try {
     const parsed = new URL(url, `http://${hostname}`);
     return parsed.hostname !== hostname;


### PR DESCRIPTION
I think we were overly strict with the CHIPS implementation for our draft mode cookies, and it wasn't being properly set. Since this isn't a tracking cookie, we don't need to allow third-party embeddings anyway. I've disabled the partitioning and set the sameSIte to lax (to allow localhost cookies in a non-HTTPS context).

Also added another check to the redirect URL to outside hosts (it needs to check for `//` URLs too... probably there is a safer way to do this across the board?).

Draft mode should work now.