### PR TITLE
Fix open redirect in astro-starter-kit draft mode handlers

### DIFF
--- a/src/pages/api/draft-mode/disable/index.ts
+++ b/src/pages/api/draft-mode/disable/index.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from 'astro';
 import { disableDraftMode } from '~/lib/draftMode';
-import { handleUnexpectedError, invalidRequestResponse, isRelativeUrl } from '../../utils';
+import { handleUnexpectedError, invalidRequestResponse, isSafeRedirectUrl } from '../../utils';
 
 /**
  * This route handler disables Draft Mode and redirects to the given URL.
@@ -12,7 +12,7 @@ export const GET: APIRoute = (event) => {
 
   try {
     // Avoid open redirect vulnerabilities
-    if (!isRelativeUrl(redirectUrl)) {
+    if (!isSafeRedirectUrl(redirectUrl, url.hostname)) {
       return invalidRequestResponse('URL must be relative!', 422);
     }
 

--- a/src/pages/api/draft-mode/enable/index.ts
+++ b/src/pages/api/draft-mode/enable/index.ts
@@ -1,7 +1,7 @@
 import type { APIRoute } from 'astro';
 import { SECRET_API_TOKEN } from 'astro:env/server';
 import { enableDraftMode } from '~/lib/draftMode';
-import { handleUnexpectedError, invalidRequestResponse, isRelativeUrl } from '../../utils';
+import { handleUnexpectedError, invalidRequestResponse, isSafeRedirectUrl } from '../../utils';
 
 /**
  * This route handler enables Draft Mode and redirects to the given URL.
@@ -20,7 +20,7 @@ export const GET: APIRoute = (event) => {
     }
 
     // Avoid open redirect vulnerabilities
-    if (!isRelativeUrl(redirectUrl)) {
+    if (!isSafeRedirectUrl(redirectUrl, url.hostname)) {
       return invalidRequestResponse('URL must be relative!', 422);
     }
 

--- a/src/pages/api/utils.ts
+++ b/src/pages/api/utils.ts
@@ -59,19 +59,21 @@ export function successfulResponse(data?: unknown, status = 200) {
   );
 }
 
-export function isRelativeUrl(path: string) {
+/**
+ * Guards against open redirect vulnerabilities.
+ *
+ * Rather than trying to enumerate every malicious pattern (`//evil.com`,
+ * `HTTP://evil.com`, leading whitespace, backslashes, encodings, …), we resolve
+ * the candidate against the current request's host and only accept it if it
+ * stays on the same hostname. Anything that resolves elsewhere — or fails to
+ * parse at all — is rejected.
+ */
+export function isSafeRedirectUrl(url: string, hostname: string): boolean {
   try {
-    // Try to create a URL object — if it succeeds without a base, it's absolute
-    new URL(path);
-    return false;
+    // The scheme is irrelevant here: we only compare hostnames.
+    const parsed = new URL(url, `http://${hostname}`);
+    return parsed.hostname === hostname;
   } catch {
-    try {
-      // Verify it can be parsed as a relative URL by providing a base
-      new URL(path, 'http://example.com');
-      return true;
-    } catch {
-      // If both attempts fail, it's not a valid URL at all
-      return false;
-    }
+    return false;
   }
 }


### PR DESCRIPTION
The previous isRelativeUrl guard classified protocol-relative URLs (e.g. //evil.com), backslash variants and similar as relative, letting them through to event.redirect(). Replace it with a hostname check that resolves the candidate against the request host and rejects anything that resolves off-host or fails to parse.

Ref: Basecamp card 'Fix open redirects in all our starters'